### PR TITLE
changed lightness to 10; Fusion Table opacity to 65

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -5,7 +5,7 @@ a:hover { color: #4B58A6; }
   max-width: none;
 }
 
-/* MODIFY polygon legend colors to match 5-color buckets in your Google Fusion Table. 
+/* MODIFY polygon legend colors to match 5-color buckets in your Google Fusion Table */
 #legend-one { border-top: 10px solid #fff5cc; }
 #legend-two { border-top: 10px solid #ffdb94; }
 #legend-three { border-top: 10px solid #ffb84d; }

--- a/css/custom.css
+++ b/css/custom.css
@@ -6,12 +6,11 @@ a:hover { color: #4B58A6; }
 }
 
 /* MODIFY polygon legend colors to match 5-color buckets in your Google Fusion Table. 
-/* This selection is based on http://colorbrewer2.org/?type=sequential&scheme=Oranges&n=5
-#legend-one { border-top: 10px solid #feedde; }
-#legend-two { border-top: 10px solid #fdbe85; }
-#legend-three { border-top: 10px solid #fd8d3c; }
-#legend-four { border-top: 10px solid #fe6550d; }
-#legend-five { border-top: 10px solid #a63603; }
+#legend-one { border-top: 10px solid #fff5cc; }
+#legend-two { border-top: 10px solid #ffdb94; }
+#legend-three { border-top: 10px solid #ffb84d; }
+#legend-four { border-top: 10px solid #ff9933; }
+#legend-five { border-top: 10px solid #ff7519; }
 #polygon-legend { background: none; clear: both; margin-bottom: 0.3em; padding: 8px 0 0 0; margin: 15px 0 0 0; list-style: none; }
 #polygon-legend li { width: 18%; float: left; margin: 0 1% 10px 0; white-space: nowrap; text-align: center; font-size: 11px; color: #77787b; }
 

--- a/css/custom.css
+++ b/css/custom.css
@@ -5,12 +5,13 @@ a:hover { color: #4B58A6; }
   max-width: none;
 }
 
-/* MODIFY polygon legend colors to match 5-color buckets in your Google Fusion Table. See also http://ColorBrewer2.org*/
-#legend-one { border-top: 10px solid #fff5cc; }
-#legend-two { border-top: 10px solid #ffdb94; }
-#legend-three { border-top: 10px solid #ffb84d; }
-#legend-four { border-top: 10px solid #ff9933; }
-#legend-five { border-top: 10px solid #ff7519; }
+/* MODIFY polygon legend colors to match 5-color buckets in your Google Fusion Table. 
+/* This selection is based on http://colorbrewer2.org/?type=sequential&scheme=Oranges&n=5
+#legend-one { border-top: 10px solid #feedde; }
+#legend-two { border-top: 10px solid #fdbe85; }
+#legend-three { border-top: 10px solid #fd8d3c; }
+#legend-four { border-top: 10px solid #fe6550d; }
+#legend-five { border-top: 10px solid #a63603; }
 #polygon-legend { background: none; clear: both; margin-bottom: 0.3em; padding: 8px 0 0 0; margin: 15px 0 0 0; list-style: none; }
 #polygon-legend li { width: 18%; float: left; margin: 0 1% 10px 0; white-space: nowrap; text-align: center; font-size: 11px; color: #77787b; }
 

--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
               <li>
                 <label class='checkbox inline'>
                   <input type='checkbox' id='cbType2'/>
-                  <span class='filter-box filter-purple'></span>
+                  <span class='filter-box filter-blue'></span>
                   Public schools
                 </label>
               </li>

--- a/js/maps_lib.js
+++ b/js/maps_lib.js
@@ -59,7 +59,7 @@ var MapsLib = {
         {
           stylers: [
             { saturation: -100 }, // MODIFY Saturation and Lightness of Google base map if needed
-            { lightness: 40 }     // Current values make thematic polygon shading stand out over base map; also adjust opacity in Google Fusion Table map
+            { lightness: 70 }     // Current values make thematic polygon shading stand out over base map; also adjust opacity in Google Fusion Table map
           ]
         }
       ]

--- a/js/maps_lib.js
+++ b/js/maps_lib.js
@@ -59,7 +59,7 @@ var MapsLib = {
         {
           stylers: [
             { saturation: -100 }, // MODIFY Saturation and Lightness of Google base map if needed
-            { lightness: 40 }     // Value of 40 makes thematic polygon shading stand out over base map; also adjust opacity in Google Fusion Table map
+            { lightness: 20 }     // Value of 40 makes thematic polygon shading stand out over base map; also adjust opacity in Google Fusion Table map
           ]
         }
       ]

--- a/js/maps_lib.js
+++ b/js/maps_lib.js
@@ -59,7 +59,7 @@ var MapsLib = {
         {
           stylers: [
             { saturation: -100 }, // MODIFY Saturation and Lightness of Google base map if needed
-            { lightness: 10 }     // Current values make thematic polygon shading stand out over base map; also adjust opacity in Google Fusion Table map
+            { lightness: 0 }     // Value of 40 makes thematic polygon shading stand out over base map; also adjust opacity in Google Fusion Table map
           ]
         }
       ]

--- a/js/maps_lib.js
+++ b/js/maps_lib.js
@@ -59,7 +59,7 @@ var MapsLib = {
         {
           stylers: [
             { saturation: -100 }, // MODIFY Saturation and Lightness of Google base map if needed
-            { lightness: 70 }     // Current values make thematic polygon shading stand out over base map; also adjust opacity in Google Fusion Table map
+            { lightness: 10 }     // Current values make thematic polygon shading stand out over base map; also adjust opacity in Google Fusion Table map
           ]
         }
       ]

--- a/js/maps_lib.js
+++ b/js/maps_lib.js
@@ -59,7 +59,7 @@ var MapsLib = {
         {
           stylers: [
             { saturation: -100 }, // MODIFY Saturation and Lightness of Google base map if needed
-            { lightness: 20 }     // Value of 40 makes thematic polygon shading stand out over base map; also adjust opacity in Google Fusion Table map
+            { lightness: 10 }     // Value of 40 makes thematic polygon shading stand out over base map; also adjust opacity in Google Fusion Table map
           ]
         }
       ]

--- a/js/maps_lib.js
+++ b/js/maps_lib.js
@@ -59,7 +59,7 @@ var MapsLib = {
         {
           stylers: [
             { saturation: -100 }, // MODIFY Saturation and Lightness of Google base map if needed
-            { lightness: 0 }     // Value of 40 makes thematic polygon shading stand out over base map; also adjust opacity in Google Fusion Table map
+            { lightness: 40 }     // Value of 40 makes thematic polygon shading stand out over base map; also adjust opacity in Google Fusion Table map
           ]
         }
       ]


### PR DESCRIPTION
Lisa and Erin,
Today I showed the Mobility App to the staff at Middletown North East Action Team, where my students will be testing it with low-income community members in mid-April.

The staff noted that they could not read the Google Map features (such as street names, parks, etc.) underneath the orange-shaded polygons.

So I made two minor changes (which you can view at https://jackdougherty.github.io/mobility-app)
- the code for the background Google Map "lightness" is reduced from 40 to 10 (which makes it darker)
- in Google Fusion Table for mobility-app, I reduced the opacity of each shading from 70 to 65%

If you like these changes, then accept this pull request.

Or if you don't like these changes, tell me and I'll switch it back.

-Jack
